### PR TITLE
Allow installing with git

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 ----------------
 Run this command in the graphical CLI:
 <pre>
-svn checkout https://github.com/Ezandora/PirateRealm/trunk/Release/
+git checkout Ezandora/PirateRealm
 </pre>
 
 

--- a/Release/dependencies.txt
+++ b/Release/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Gain/branches/Release/
+github Ezandora/Gain Release

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,3 @@
+{
+   "root_directory": "Release"
+}


### PR DESCRIPTION
github is removing SVN support on Jan 8, 2024
KoLmafia can install scripts via GIT.

1) If you do not have a branch with your code, manifest.json tells KoLmafia where the root of the code is.
2) dependencies.txt can have "github" syntax which will look for either SVN or GIT installation and will install via GIT if not yet installed.